### PR TITLE
Hammerhead: Keep mpdecision and thermal-engine-hh naming default

### DIFF
--- a/hammerhead/device-partial.mk
+++ b/hammerhead/device-partial.mk
@@ -20,7 +20,7 @@ PRODUCT_COPY_FILES := \
     vendor/qcom/hammerhead/proprietary/ds_fmc_appd:system/bin/ds_fmc_appd:qcom \
     vendor/qcom/hammerhead/proprietary/irsc_util:system/bin/irsc_util:qcom \
     vendor/qcom/hammerhead/proprietary/mm-qcamera-daemon:system/bin/mm-qcamera-daemon:qcom \
-    vendor/qcom/hammerhead/proprietary/mpdecision:system/bin/mpdecision_disabled:qcom \
+    vendor/qcom/hammerhead/proprietary/mpdecision:system/bin/mpdecision:qcom \
     vendor/qcom/hammerhead/proprietary/netmgrd:system/bin/netmgrd:qcom \
     vendor/qcom/hammerhead/proprietary/nl_listener:system/bin/nl_listener:qcom \
     vendor/qcom/hammerhead/proprietary/port-bridge:system/bin/port-bridge:qcom \
@@ -30,7 +30,7 @@ PRODUCT_COPY_FILES := \
     vendor/qcom/hammerhead/proprietary/rmt_storage:system/bin/rmt_storage:qcom \
     vendor/qcom/hammerhead/proprietary/sensors.qcom:system/bin/sensors.qcom:qcom \
     vendor/qcom/hammerhead/proprietary/subsystem_ramdump:system/bin/subsystem_ramdump:qcom \
-    vendor/qcom/hammerhead/proprietary/thermal-engine-hh:system/bin/thermal-engine-hh_disabled:qcom \
+    vendor/qcom/hammerhead/proprietary/thermal-engine-hh:system/bin/thermal-engine-hh:qcom \
     vendor/qcom/hammerhead/proprietary/time_daemon:system/bin/time_daemon:qcom \
     vendor/qcom/hammerhead/proprietary/usbhub:system/bin/usbhub:qcom \
     vendor/qcom/hammerhead/proprietary/usbhub_init:system/bin/usbhub_init:qcom \


### PR DESCRIPTION
Kernel with built-in hotplugging driver and/or thermal management should handle this in a script (stop mpdecision...) or rc file (not start the service on boot).

Change-Id: I3cf06c96851f3056bc03db823cf669d088aecf1c
Signed-off-by: Jean-Pierre Rasquin yank555.lu@gmail.com
